### PR TITLE
Fix "call to member function prepare() on null" when trying to delete a comment

### DIFF
--- a/Server/scripts/deleteLevelCommentReq.php
+++ b/Server/scripts/deleteLevelCommentReq.php
@@ -35,6 +35,7 @@ class deleteLevelCommentReq extends RequestResponse {
 		}
 		
 		//Insert level data
+		$db = $this->getConnection();
 		$stmt = $db->prepare("DELETE FROM " . $this->config['table_comments'] .
 			" WHERE `commentId`=:commentId AND `userId`=:userId");
 		$stmt->bindParam(':commentId', $json['body']['messageId'], PDO::PARAM_INT);


### PR DESCRIPTION
The delete comment script is simply missing one line of code to get a reference to the database before running its SQL queries.